### PR TITLE
Validate popstate state before accessing history

### DIFF
--- a/src/story.js
+++ b/src/story.js
@@ -186,7 +186,7 @@ _.extend(Story.prototype, {
 		$(window).on('popstate', function(event) {
 			var state = event.originalEvent.state;
 
-			if (state) {
+			if (state && Array.isArray(state.history)) {
 				this.state = state.state;
 				this.history = state.history;
 				this.checkpointName = state.checkpointName;


### PR DESCRIPTION
## Summary

Fixes exercism/website#8590

The `popstate` handler in `Story.start()` assumed any truthy `event.state` was pushed by the Story engine. When the Story is used in an app alongside Turbo (or other libraries that manage browser history), the handler receives non-Story state objects that are truthy but lack a `history` array property. This causes:

```
TypeError: Cannot read properties of undefined (reading 'length')
```

- Added `Array.isArray(state.history)` guard to the `if (state)` check so only Story-pushed state objects are processed
- Non-Story state objects now fall through harmlessly

## Test plan

- [x] Verified the `else if` branch is safe: `this.history` is initialized to `[]` in the constructor and only overwritten inside the now-guarded `if` block
- [x] Story-internal popstate events (pushed via `window.history.pushState` with `{state, history, checkpointName}`) always have `Array.isArray(state.history) === true`, so they continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)